### PR TITLE
Added Bug_2

### DIFF
--- a/bugs/Avneesh_bug2.txt
+++ b/bugs/Avneesh_bug2.txt
@@ -1,0 +1,2 @@
+When Add is clicked it sets all text boxes to default but Book Uploader stil hold the book name and details.
+It should loose all data and should Display "No File chosen".


### PR DESCRIPTION
__10__ 

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
<!-- Add issue numbers both above and below this comment, do not remove __ or #-->
<!-- You must remove Fixes line if you are reporting a bug -->

#10 
#### Short description of what this resolves:
When Add is clicked it sets all text boxes to default but Book Uploader still hold the book name and details.
It should loose all data and should Display "No File chosen".
![image](https://user-images.githubusercontent.com/54072374/74512629-b8753380-4f2e-11ea-9304-fb7c0411c65d.png)
![image](https://user-images.githubusercontent.com/54072374/74512677-d2af1180-4f2e-11ea-9a31-577a625186a5.png)



#### Changes proposed in this pull request and/or Screenshots of changes:

-
-
-
